### PR TITLE
Modify project init task

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ chmod +x $HOME/.yarn/bin/polar
 ### Initialize a project
 
 ```bash
-polar init <project-directory>
+polar init <project-name>
 ```
 
-This will create a directory `secret-project` with boiler-plate code inside the given directory.
+This will create a directory <project-name> inside current directory with boiler-plate code.
 
 ### Compile the project
 

--- a/packages/polar/package.json
+++ b/packages/polar/package.json
@@ -54,6 +54,7 @@
     "find-up": "^5.0.0",
     "fs-extra": "^10.0.0",
     "glob": "^7.1.7",
+    "gunzip-file": "^0.1.1",
     "node-fetch": "^2.6.1",
     "semver": "^7.3.5"
   },

--- a/packages/polar/src/builtin-tasks/deploy.ts
+++ b/packages/polar/src/builtin-tasks/deploy.ts
@@ -1,27 +1,31 @@
-import chalk from "chalk";
-import fsExtra from "fs-extra";
-import path from "path";
-
 import { task } from "../internal/core/config/config-env";
 import { isCwdProjectDir } from "../internal/core/project-structure";
+import { compress } from "../lib/deploy/compress";
 import type { PolarRuntimeEnvironment } from "../types";
 import { TASK_DEPLOY } from "./task-names";
 
 export default function (): void {
   task(TASK_DEPLOY, "Compresses the contracts files and deploys them to the network specified")
-    .setAction(async (env: PolarRuntimeEnvironment) => {
-      if (!isCwdProjectDir()) {
-        console.log(`Not in a valid polar project repo, exiting`);
-        process.exit(1);
-      }
-
-      // generated compressed wasm file using docker image
-      // choose image based on single or multi contact repo
-
-      // store compress wasm in secret network container
-    });
+    .addPositionalParam<string>("networkName", "Name of network to deploy to")
+    .setAction(deployTask);
 }
 
 export interface TaskArgs {
-  network: string[]
+  networkName: string[]
+}
+
+async function deployTask (
+  { networkName }: TaskArgs,
+  env: PolarRuntimeEnvironment
+): Promise<void> {
+  if (!isCwdProjectDir()) {
+    console.log(`Not in a valid polar project repo, exiting`);
+    process.exit(1);
+  }
+
+  // generated compressed wasm file using docker image
+  // choose image based on single or multi contact repo
+  await compress(networkName, env);
+
+  // store compress wasm in secret network container
 }

--- a/packages/polar/src/builtin-tasks/deploy.ts
+++ b/packages/polar/src/builtin-tasks/deploy.ts
@@ -21,3 +21,7 @@ export default function (): void {
       // store compress wasm in secret network container
     });
 }
+
+export interface TaskArgs {
+  network: string[]
+}

--- a/packages/polar/src/builtin-tasks/init.ts
+++ b/packages/polar/src/builtin-tasks/init.ts
@@ -4,9 +4,9 @@ import { TASK_INIT } from "./task-names";
 
 export default function (): void {
   task(TASK_INIT, "Initializes a new project in the given directory")
-    .addPositionalParam<string>("projectLocation", "Location of project")
-    .setAction(async ({ newProjectLocation }:
-    { newProjectLocation: string }, _) => {
-      await createProject(newProjectLocation);
+    .addPositionalParam<string>("projectName", "Name of project")
+    .setAction(async ({ projectName }:
+    { projectName: string }, _) => {
+      await createProject(projectName);
     });
 }

--- a/packages/polar/src/internal/cli/project-creation.ts
+++ b/packages/polar/src/internal/cli/project-creation.ts
@@ -53,7 +53,7 @@ function printSuggestedCommands (projectName: string): void {
   const currDir = process.cwd();
   const projectPath = path.join(currDir, projectName);
   console.log(`Success! Created project at ${chalk.greenBright(projectPath)}.`);
-  // console.log(`Inside that directory, you can run several commands:`);
+  // TODO: console.log(`Inside that directory, you can run several commands:`);
   // list commands and respective description
   const npx =
     getExecutionMode() === ExecutionMode.EXECUTION_MODE_GLOBAL_INSTALLATION

--- a/packages/polar/src/internal/cli/project-creation.ts
+++ b/packages/polar/src/internal/cli/project-creation.ts
@@ -20,13 +20,15 @@ async function printWelcomeMessage (): Promise<void> {
     chalk.cyan(`★ Welcome to ${POLAR_NAME} v${packageJson.version}`));
 }
 
-function copySampleProject (location: string): void {
+function copySampleProject (projectName: string): void {
   const packageRoot = getPackageRoot();
   const sampleProjDir = path.join(packageRoot, "sample-project");
 
-  console.log(chalk.greenBright("Initializing new workspace in " + process.cwd() + "."));
+  const currDir = process.cwd();
+  const projectPath = path.join(currDir, projectName);
+  console.log(chalk.greenBright("Initializing new project in " + projectPath + "."));
 
-  fsExtra.copySync(sampleProjDir, location, {
+  fsExtra.copySync(sampleProjDir, projectPath, {
     // User doesn't choose the directory so overwrite should be avoided
     overwrite: false,
     filter: (src: string, dest: string) => {
@@ -47,15 +49,21 @@ function copySampleProject (location: string): void {
   });
 }
 
-function printSuggestedCommands (): void {
+function printSuggestedCommands (projectName: string): void {
+  const currDir = process.cwd();
+  const projectPath = path.join(currDir, projectName);
+  console.log(`Success! Created project at ${chalk.greenBright(projectPath)}.`);
+  // console.log(`Inside that directory, you can run several commands:`);
+  // list commands and respective description
   const npx =
     getExecutionMode() === ExecutionMode.EXECUTION_MODE_GLOBAL_INSTALLATION
       ? ""
       : "npx ";
 
-  console.log(`Try running some of the following tasks:`);
-  console.log(`  ${npx}${POLAR_NAME} compile`);
+  console.log(`Begin by typing:`);
+  console.log(`  cd ${projectName}`);
   console.log(`  ${npx}${POLAR_NAME} help`);
+  console.log(`  ${npx}${POLAR_NAME} compile`);
 }
 
 async function printPluginInstallationInstructions (): Promise<void> {
@@ -68,12 +76,10 @@ async function printPluginInstallationInstructions (): Promise<void> {
   console.log(`  ${cmd.join(" ")}`);
 }
 
-export async function createProject (location: string): Promise<any> {
+export async function createProject (projectName: string): Promise<any> {
   await printWelcomeMessage();
-  if (location === undefined) { location = process.cwd(); }
 
-  location = path.join(location, "secret-project");
-  copySampleProject(location);
+  copySampleProject(projectName);
 
   let shouldShowInstallationInstructions = true;
 
@@ -109,7 +115,7 @@ export async function createProject (location: string): Promise<any> {
     console.log(``);
   }
 
-  printSuggestedCommands();
+  printSuggestedCommands(projectName);
 }
 
 function createConfirmationPrompt (name: string, message: string) { // eslint-disable-line @typescript-eslint/explicit-function-return-type

--- a/packages/polar/src/internal/core/params/polar-params.ts
+++ b/packages/polar/src/internal/core/params/polar-params.ts
@@ -50,6 +50,7 @@ export const POLAR_PARAM_DEFINITIONS: ParamDefinitions = {
   },
   verbose: {
     name: "verbose",
+    shortName: "v",
     defaultValue: false,
     description: "Enables verbose logging",
     type: types.boolean,

--- a/packages/polar/src/internal/core/params/polar-params.ts
+++ b/packages/polar/src/internal/core/params/polar-params.ts
@@ -22,6 +22,7 @@ export const POLAR_PARAM_DEFINITIONS: ParamDefinitions = {
   },
   version: {
     name: "version",
+    shortName: "v",
     defaultValue: false,
     description: "Shows version and exit.",
     type: types.boolean,
@@ -50,7 +51,6 @@ export const POLAR_PARAM_DEFINITIONS: ParamDefinitions = {
   },
   verbose: {
     name: "verbose",
-    shortName: "v",
     defaultValue: false,
     description: "Enables verbose logging",
     type: types.boolean,

--- a/packages/polar/src/internal/core/project-structure.ts
+++ b/packages/polar/src/internal/core/project-structure.ts
@@ -8,6 +8,7 @@ export const JS_CONFIG_FILENAME = "polar.config.js";
 export const CONTRACTS_DIR = "contracts";
 export const ARTIFACTS_DIR = "artifacts";
 export const CACHE_DIR = join(ARTIFACTS_DIR, ".cache");
+export const CONTRACTS_OUT_DIR = join(ARTIFACTS_DIR, "contracts");
 export const TARGET_DIR = "target/wasm32-unknown-unknown/release/";
 export const SCHEMA_DIR = "schema";
 

--- a/packages/polar/src/internal/core/project-structure.ts
+++ b/packages/polar/src/internal/core/project-structure.ts
@@ -12,6 +12,9 @@ export const CONTRACTS_OUT_DIR = join(ARTIFACTS_DIR, "contracts");
 export const TARGET_DIR = "target/wasm32-unknown-unknown/release/";
 export const SCHEMA_DIR = "schema";
 
+export const singleImageVersion = "0.11.5";
+export const multiImageVersion = "0.11.5";
+
 export function isCwdInsideProject (): boolean {
   return Boolean(findUp.sync(JS_CONFIG_FILENAME));
 }

--- a/packages/polar/src/lib/deploy/compress.ts
+++ b/packages/polar/src/lib/deploy/compress.ts
@@ -1,0 +1,49 @@
+import chalk from "chalk";
+import { execSync } from "child_process";
+import fs, { readdirSync } from "fs-extra";
+import path from "path";
+import zlib from "zlib";
+
+import {
+  ARTIFACTS_DIR,
+  assertDir,
+  CONTRACTS_DIR,
+  CONTRACTS_OUT_DIR
+} from "../../internal/core/project-structure";
+import { cmpStr } from "../../internal/util/strings";
+import type { PolarRuntimeEnvironment } from "../../types";
+
+export async function compress (
+  networkName: string[],
+  env: PolarRuntimeEnvironment
+): Promise<void> {
+  const paths = readdirSync(CONTRACTS_DIR);
+  if (paths.includes("Cargo.toml")) { // Only one contract in the contracts dir and compile in contracts dir only
+    const imageVersion = `0.11.5`;
+    const dockerCmd = `docker run --rm -v ${path.resolve(CONTRACTS_DIR)}:/code \
+                  --mount type=volume,source=${path.basename(ARTIFACTS_DIR)},target=/code/target \
+                  --mount type=volume,source=${path.basename(ARTIFACTS_DIR)},target=/usr/local/cargo/registry \
+                  cosmwasm/rust-optimizer:${imageVersion}`;
+
+    console.log(chalk.greenBright(`Creating compressed .wasm file using cosmwasm/rust-optimizer:${imageVersion}...`));
+    execSync(dockerCmd, { stdio: 'inherit' });
+
+    const fileContents = fs.createReadStream(path.join(CONTRACTS_DIR, "contract.wasm.gz"));
+    const writeStream = fs.createWriteStream(path.join(CONTRACTS_OUT_DIR, "contract.wasm"));
+    const unzip = zlib.createGunzip();
+
+    fileContents.pipe(unzip).pipe(writeStream);
+    fs.unlinkSync(path.join(CONTRACTS_DIR, "contract.wasm.gz"));
+    console.log(`Created file ${path.join(CONTRACTS_OUT_DIR, "contract.wasm")}`);
+  } else { // Multiple contracts and each should be compiled by going inside each of them
+    const imageVersion = `0.11.5`;
+    const dockerCmd = `docker run --rm -v ${path.resolve(CONTRACTS_DIR)}:/code \
+                  --mount type=volume,source=${path.basename(ARTIFACTS_DIR)},target=/code/target \
+                  --mount type=volume,source=${path.basename(ARTIFACTS_DIR)},target=/usr/local/cargo/registry \
+                  cosmwasm/workspace-optimizer:${imageVersion}`;
+
+    console.log(chalk.greenBright(`Creating compressed .wasm file using cosmwasm/workspace-optimizer:${imageVersion}...`));
+    execSync(dockerCmd, { stdio: 'inherit' });
+    console.log(`Generated .wasm files in ${ARTIFACTS_DIR}`);
+  }
+}

--- a/packages/polar/src/lib/deploy/compress.ts
+++ b/packages/polar/src/lib/deploy/compress.ts
@@ -8,7 +8,9 @@ import {
   ARTIFACTS_DIR,
   assertDir,
   CONTRACTS_DIR,
-  CONTRACTS_OUT_DIR
+  CONTRACTS_OUT_DIR,
+  multiImageVersion,
+  singleImageVersion
 } from "../../internal/core/project-structure";
 import { cmpStr } from "../../internal/util/strings";
 import type { PolarRuntimeEnvironment } from "../../types";
@@ -19,13 +21,12 @@ export async function compress (
 ): Promise<void> {
   const paths = readdirSync(CONTRACTS_DIR);
   if (paths.includes("Cargo.toml")) { // Only one contract in the contracts dir and compile in contracts dir only
-    const imageVersion = `0.11.5`;
     const dockerCmd = `docker run --rm -v ${path.resolve(CONTRACTS_DIR)}:/code \
                   --mount type=volume,source=${path.basename(ARTIFACTS_DIR)},target=/code/target \
                   --mount type=volume,source=${path.basename(ARTIFACTS_DIR)},target=/usr/local/cargo/registry \
-                  cosmwasm/rust-optimizer:${imageVersion}`;
+                  cosmwasm/rust-optimizer:${singleImageVersion}`;
 
-    console.log(chalk.greenBright(`Creating compressed .wasm file using cosmwasm/rust-optimizer:${imageVersion}...`));
+    console.log(chalk.greenBright(`Creating compressed .wasm file using cosmwasm/rust-optimizer:${singleImageVersion}...`));
     execSync(dockerCmd, { stdio: 'inherit' });
 
     const fileContents = fs.createReadStream(path.join(CONTRACTS_DIR, "contract.wasm.gz"));
@@ -36,13 +37,12 @@ export async function compress (
     fs.unlinkSync(path.join(CONTRACTS_DIR, "contract.wasm.gz"));
     console.log(`Created file ${path.join(CONTRACTS_OUT_DIR, "contract.wasm")}`);
   } else { // Multiple contracts and each should be compiled by going inside each of them
-    const imageVersion = `0.11.5`;
     const dockerCmd = `docker run --rm -v ${path.resolve(CONTRACTS_DIR)}:/code \
                   --mount type=volume,source=${path.basename(ARTIFACTS_DIR)},target=/code/target \
                   --mount type=volume,source=${path.basename(ARTIFACTS_DIR)},target=/usr/local/cargo/registry \
-                  cosmwasm/workspace-optimizer:${imageVersion}`;
+                  cosmwasm/workspace-optimizer:${multiImageVersion}`;
 
-    console.log(chalk.greenBright(`Creating compressed .wasm file using cosmwasm/workspace-optimizer:${imageVersion}...`));
+    console.log(chalk.greenBright(`Creating compressed .wasm file using cosmwasm/workspace-optimizer:${multiImageVersion}...`));
     execSync(dockerCmd, { stdio: 'inherit' });
     console.log(`Generated .wasm files in ${ARTIFACTS_DIR}`);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1800,6 +1800,11 @@ growl@1.10.5:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
+gunzip-file@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/gunzip-file/-/gunzip-file-0.1.1.tgz#29b3a3cc8a6a58ce553812bc0b13f0a0bb3a5ee2"
+  integrity sha1-KbOjzIpqWM5VOBK8CxPwoLs6XuI=
+
 handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"


### PR DESCRIPTION
Something similar to what create-react-app does:

```bash
Success! Created helloreact at /home/uditgulati/helloreact
Inside that directory, you can run several commands:

  yarn start
    Starts the development server.

  yarn build
    Bundles the app into static files for production.

  yarn test
    Starts the test runner.

  yarn eject
    Removes this tool and copies build dependencies, configuration files
    and scripts into the app directory. If you do this, you can’t go back!

We suggest that you begin by typing:

  cd helloreact
  yarn start

Happy hacking!
```