### PR TITLE
Support compiler version control from config file

### DIFF
--- a/packages/polar/package.json
+++ b/packages/polar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secret-polar",
-  "version": "0.4.4",
+  "version": "0.4.3",
   "main": "dist/src/index.js",
   "authors": [
     {

--- a/packages/polar/package.json
+++ b/packages/polar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secret-polar",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "main": "dist/src/index.js",
   "authors": [
     {

--- a/packages/polar/sample-project/polar.config.js
+++ b/packages/polar/sample-project/polar.config.js
@@ -35,5 +35,8 @@ module.exports = {
   },
   mocha: {
     timeout: 60000
+  },
+  rust: {
+    version: "1.55.0"
   }
 };

--- a/packages/polar/src/builtin-tasks/compile.ts
+++ b/packages/polar/src/builtin-tasks/compile.ts
@@ -1,6 +1,6 @@
 import { boolean } from "../../src/internal/core/params/argument-types";
 import { task } from "../internal/core/config/config-env";
-import { checkEnv } from "../lib/compile/checkEnv";
+import { canCompile, checkEnv } from "../lib/compile/checkEnv";
 import { compile } from "../lib/compile/compile";
 import type { PolarRuntimeEnvironment } from "../types";
 import { TASK_COMPILE } from "./task-names";
@@ -23,17 +23,15 @@ export interface TaskArgs {
   force: boolean
 }
 
-function compileTask (
+async function compileTask (
   { docker, sourceDir, force }: TaskArgs,
   env: PolarRuntimeEnvironment
 ): Promise<void> {
-  if (!canCompile(env)) { // check if proper version of rust wasm compiler is installed
+  // check if proper version of rust wasm compiler is installed
+  // If not, install it
+  if (!(await canCompile(env))) {
     process.exit(1);
   }
 
-  return compile(docker, sourceDir, force);
-}
-
-function canCompile (env: PolarRuntimeEnvironment): boolean {
-  return checkEnv({ rustcVersion: '1.50.0', cargoVersion: '1.50.0' });
+  return await compile(docker, sourceDir, force);
 }

--- a/packages/polar/src/builtin-tasks/compile.ts
+++ b/packages/polar/src/builtin-tasks/compile.ts
@@ -1,6 +1,6 @@
 import { boolean } from "../../src/internal/core/params/argument-types";
 import { task } from "../internal/core/config/config-env";
-import { canCompile, checkEnv } from "../lib/compile/checkEnv";
+import { canCompile } from "../lib/compile/checkEnv";
 import { compile } from "../lib/compile/compile";
 import type { PolarRuntimeEnvironment } from "../types";
 import { TASK_COMPILE } from "./task-names";

--- a/packages/polar/src/builtin-tasks/install.ts
+++ b/packages/polar/src/builtin-tasks/install.ts
@@ -1,6 +1,7 @@
 import { execSync } from "child_process";
 
 import { task } from "../internal/core/config/config-env";
+import { PolarRuntimeEnvironment, TaskArguments } from "../types";
 import { TASK_INSTALL } from "./task-names";
 
 export default function (): void {
@@ -8,13 +9,18 @@ export default function (): void {
     .setAction(setupRust);
 }
 
-async function setupRust (): Promise<boolean> {
+async function setupRust (
+  _taskArgs: TaskArguments, env: PolarRuntimeEnvironment
+): Promise<boolean> {
   execSync(`curl --proto '=https' --tlsv1.2 -sSf -y https://sh.rustup.rs | sh`);
   execSync(`export PATH="${process.env.HOME}/.cargo/bin:${process.env.PATH}"`); // eslint-disable-line  @typescript-eslint/restrict-template-expressions
-  execSync(`rustup default stable`);
+  if (env.config.rust) {
+    execSync(`rustup default ${env.config.rust.version}`);
+  } else {
+    execSync(`rustup default stable`);
+  }
   execSync(`rustup target list --installed`);
   execSync(`rustup target add wasm32-unknown-unknown`);
-  if (process.platform === "linux" || process.platform === "win32") { execSync(`sudo apt install build-essential`); }
 
   return true;
 }

--- a/packages/polar/src/builtin-tasks/install.ts
+++ b/packages/polar/src/builtin-tasks/install.ts
@@ -6,12 +6,16 @@ import { TASK_INSTALL } from "./task-names";
 
 export default function (): void {
   task(TASK_INSTALL, "Setup rust compiler")
-    .setAction(setupRust);
+    .setAction(taskRust);
 }
 
-async function setupRust (
+async function taskRust (
   _taskArgs: TaskArguments, env: PolarRuntimeEnvironment
 ): Promise<boolean> {
+  return await setupRust(env);
+}
+
+export async function setupRust (env: PolarRuntimeEnvironment): Promise<boolean> {
   execSync(`curl --proto '=https' --tlsv1.2 -sSf -y https://sh.rustup.rs | sh`);
   execSync(`export PATH="${process.env.HOME}/.cargo/bin:${process.env.PATH}"`); // eslint-disable-line  @typescript-eslint/restrict-template-expressions
   if (env.config.rust) {

--- a/packages/polar/src/builtin-tasks/install.ts
+++ b/packages/polar/src/builtin-tasks/install.ts
@@ -14,8 +14,6 @@ async function setupRust (): Promise<boolean> {
   execSync(`rustup default stable`);
   execSync(`rustup target list --installed`);
   execSync(`rustup target add wasm32-unknown-unknown`);
-  execSync(`rustup install nightly`);
-  execSync(`rustup target add wasm32-unknown-unknown --toolchain nightly`);
   if (process.platform === "linux" || process.platform === "win32") { execSync(`sudo apt install build-essential`); }
 
   return true;

--- a/packages/polar/src/types.ts
+++ b/packages/polar/src/types.ts
@@ -232,7 +232,7 @@ export interface Network {
 }
 
 interface RustVersion {
-  version: number
+  version: string
 }
 
 export interface ResolvedConfig extends PolarUserConfig {

--- a/packages/polar/src/types.ts
+++ b/packages/polar/src/types.ts
@@ -231,8 +231,13 @@ export interface Network {
   // provider:
 }
 
+interface RustVersion {
+  version: number
+}
+
 export interface ResolvedConfig extends PolarUserConfig {
   paths?: ProjectPathsConfig
+  rust?: RustVersion
   networks: Networks
 }
 


### PR DESCRIPTION
- User doesn't need to install rust, `polar compile` command will do that, user only need to specify compiler version in polar.config.js