### PR TITLE
Checkpoints fixes

### DIFF
--- a/packages/polar/src/builtin-tasks/run.ts
+++ b/packages/polar/src/builtin-tasks/run.ts
@@ -12,6 +12,7 @@ import { TASK_RUN } from "./task-names";
 
 interface Input {
   scripts: string[]
+  skipCheckpoints: boolean
 }
 
 export function filterNonExistent (scripts: string[]): string[] {
@@ -39,7 +40,7 @@ async function runScripts (
 }
 
 async function executeRunTask (
-  { scripts }: Input,
+  { scripts, skipCheckpoints }: Input,
   runtimeEnv: PolarRuntimeEnvironment
   // eslint-disable-next-line
 ): Promise<any> {
@@ -50,6 +51,10 @@ async function executeRunTask (
     throw new PolarError(ERRORS.BUILTIN_TASKS.RUN_FILES_NOT_FOUND, {
       scripts: nonExistent
     });
+  }
+
+  if (skipCheckpoints) { // used by Contract() class to skip checkpoints
+    runtimeEnv.runtimeArgs.useCheckpoints = false;
   }
 
   await runScripts(
@@ -67,5 +72,6 @@ export default function (): void {
       "scripts",
       "A js file to be run within polar's environment"
     )
+    .addFlag("skipCheckpoints", "do not read from or write checkpoints")
     .setAction((input, env) => executeRunTask(input, env));
 }

--- a/packages/polar/src/builtin-tasks/test.ts
+++ b/packages/polar/src/builtin-tasks/test.ts
@@ -58,6 +58,8 @@ async function executeTestTask (
     });
   }
 
+  runtimeEnv.runtimeArgs.command = "test"; // used by Contract() class to skip artifacts
+
   await runTests(
     runtimeEnv,
     assertDirChildren(TESTS_DIR, tests),

--- a/packages/polar/src/builtin-tasks/test.ts
+++ b/packages/polar/src/builtin-tasks/test.ts
@@ -59,6 +59,7 @@ async function executeTestTask (
   }
 
   runtimeEnv.runtimeArgs.command = "test"; // used by Contract() class to skip artifacts
+  runtimeEnv.runtimeArgs.useCheckpoints = false;
 
   await runTests(
     runtimeEnv,

--- a/packages/polar/src/internal/core/params/polar-params.ts
+++ b/packages/polar/src/internal/core/params/polar-params.ts
@@ -20,6 +20,15 @@ export const POLAR_PARAM_DEFINITIONS: ParamDefinitions = {
     isOptional: true,
     isVariadic: false
   },
+  useCheckpoints: {
+    name: "useCheckpoints",
+    defaultValue: true,
+    description: "Specify if checkpoints should be used.",
+    type: types.boolean,
+    isFlag: true,
+    isOptional: true,
+    isVariadic: false
+  },
   showStackTraces: {
     name: "showStackTraces",
     defaultValue: false,

--- a/packages/polar/src/internal/core/params/polar-params.ts
+++ b/packages/polar/src/internal/core/params/polar-params.ts
@@ -11,6 +11,15 @@ export const POLAR_PARAM_DEFINITIONS: ParamDefinitions = {
     isFlag: false,
     isVariadic: false
   },
+  command: {
+    name: "command",
+    defaultValue: "",
+    description: "Name of polar task ran.",
+    type: types.string,
+    isFlag: false,
+    isOptional: true,
+    isVariadic: false
+  },
   showStackTraces: {
     name: "showStackTraces",
     defaultValue: false,

--- a/packages/polar/src/lib/deploy/contract.ts
+++ b/packages/polar/src/lib/deploy/contract.ts
@@ -160,7 +160,8 @@ export class Contract {
     // Load checkpoints
     this.checkpointPath = path.join(ARTIFACTS_DIR, "checkpoints", `${this.contractName}.yaml`);
     // file exist load it else create new checkpoint
-    if (fs.existsSync(this.checkpointPath)) {
+    // skip checkpoints if test command is run
+    if (fs.existsSync(this.checkpointPath) && this.env.runtimeArgs.command !== "test") {
       this.checkpointData = loadCheckpoint(this.checkpointPath);
       const contractHash = this.checkpointData[this.env.network.name].deployInfo?.contractCodeHash;
       const contractCodeId = this.checkpointData[this.env.network.name].deployInfo?.codeId;
@@ -233,10 +234,13 @@ export class Contract {
       contractCodeHash: contractCodeHash,
       deployTimestamp: String(new Date())
     };
-    this.checkpointData[this.env.network.name] =
-      { ...this.checkpointData[this.env.network.name], deployInfo };
+
+    if (this.env.runtimeArgs.command !== "test") {
+      this.checkpointData[this.env.network.name] =
+        { ...this.checkpointData[this.env.network.name], deployInfo };
+      persistCheckpoint(this.checkpointPath, this.checkpointData);
+    }
     this.contractCodeHash = contractCodeHash;
-    persistCheckpoint(this.checkpointPath, this.checkpointData);
 
     return deployInfo;
   }
@@ -268,9 +272,11 @@ export class Contract {
       instantiateTimestamp: String(new Date())
     };
 
-    this.checkpointData[this.env.network.name] =
-      { ...this.checkpointData[this.env.network.name], instantiateInfo };
-    persistCheckpoint(this.checkpointPath, this.checkpointData);
+    if (this.env.runtimeArgs.command !== "test") {
+      this.checkpointData[this.env.network.name] =
+        { ...this.checkpointData[this.env.network.name], instantiateInfo };
+      persistCheckpoint(this.checkpointPath, this.checkpointData);
+    }
     return instantiateInfo;
   }
 

--- a/packages/polar/src/lib/deploy/contract.ts
+++ b/packages/polar/src/lib/deploy/contract.ts
@@ -160,8 +160,9 @@ export class Contract {
     // Load checkpoints
     this.checkpointPath = path.join(ARTIFACTS_DIR, "checkpoints", `${this.contractName}.yaml`);
     // file exist load it else create new checkpoint
-    // skip checkpoints if test command is run
-    if (fs.existsSync(this.checkpointPath) && this.env.runtimeArgs.command !== "test") {
+    // skip checkpoints if test command is run, or skip-checkpoints is passed
+    if (fs.existsSync(this.checkpointPath) &&
+    this.env.runtimeArgs.useCheckpoints === true) {
       this.checkpointData = loadCheckpoint(this.checkpointPath);
       const contractHash = this.checkpointData[this.env.network.name].deployInfo?.contractCodeHash;
       const contractCodeId = this.checkpointData[this.env.network.name].deployInfo?.codeId;
@@ -235,7 +236,7 @@ export class Contract {
       deployTimestamp: String(new Date())
     };
 
-    if (this.env.runtimeArgs.command !== "test") {
+    if (this.env.runtimeArgs.useCheckpoints === true) {
       this.checkpointData[this.env.network.name] =
         { ...this.checkpointData[this.env.network.name], deployInfo };
       persistCheckpoint(this.checkpointPath, this.checkpointData);
@@ -276,7 +277,7 @@ export class Contract {
       instantiateTimestamp: initTimestamp
     };
 
-    if (this.env.runtimeArgs.command !== "test") {
+    if (this.env.runtimeArgs.useCheckpoints === true) {
       this.checkpointData[this.env.network.name] =
         { ...this.checkpointData[this.env.network.name], instantiateInfo };
       persistCheckpoint(this.checkpointPath, this.checkpointData);

--- a/packages/polar/src/lib/deploy/contract.ts
+++ b/packages/polar/src/lib/deploy/contract.ts
@@ -264,12 +264,16 @@ export class Contract {
     }
     const signingClient = await getSigningClient(this.env.network, accountVal);
 
+    const initTimestamp = String(new Date());
+    label = (this.env.runtimeArgs.command === "test")
+      ? `deploy ${this.contractName} ${initTimestamp}` : label;
+    console.log(`Instantiating with label: ${label}`);
     const contract = await signingClient.instantiate(this.codeId, initArgs, label);
     this.contractAddress = contract.contractAddress;
 
     const instantiateInfo: InstantiateInfo = {
       contractAddress: this.contractAddress,
-      instantiateTimestamp: String(new Date())
+      instantiateTimestamp: initTimestamp
     };
 
     if (this.env.runtimeArgs.command !== "test") {

--- a/packages/polar/src/types.ts
+++ b/packages/polar/src/types.ts
@@ -251,6 +251,7 @@ export interface ResolvedConfig extends PolarUserConfig {
  */
 export interface RuntimeArgs {
   network: string
+  command?: string
   showStackTraces: boolean
   version: boolean
   help: boolean

--- a/packages/polar/src/types.ts
+++ b/packages/polar/src/types.ts
@@ -252,6 +252,7 @@ export interface ResolvedConfig extends PolarUserConfig {
 export interface RuntimeArgs {
   network: string
   command?: string
+  useCheckpoints?: boolean
   showStackTraces: boolean
   version: boolean
   help: boolean


### PR DESCRIPTION
+ `polar test` skips checkpoints.
+ `polar run --skip-checkpoints` skips checkpoints.
+ label value is overwritten by `deploy <contract_name> <curr_ts>`, so it's always unique and no need to edit test every time.